### PR TITLE
updated middleHighProcessData

### DIFF
--- a/include/RE/M/MiddleHighProcessData.h
+++ b/include/RE/M/MiddleHighProcessData.h
@@ -183,7 +183,7 @@ namespace RE
 		NiPointer<bhkCharacterController>              charController;              // 250
 		BSTSmartPointer<bhkRagdollPenetrationUtil>     penetrationDetectUtil;       // 258
 		InventoryEntryData*                            rightHand;                   // 260
-		InventoryEntryData*                            bothHands;                   // 268
+		InventoryEntryData*                            currentAmmo;                 // 268
 		NiPointer<QueuedFile>                          bodyPartPreload;             // 270
 		void*                                          BSCloneReserver;             // 278
 		TESIdleForm*                                   lastIdlePlayed;              // 280


### PR DESCRIPTION
Fixed   bothHands to  -> currentAmmo;  // 268
This field holds current equipped ammo as entryData
Approve - AIProcess::GetCurrentAmmoEntry_14067A420 -> returns this field. In game tests returned only ammo, no weapon or else
Goold example in - Actor::DetachArrow_140624280